### PR TITLE
Add preserveHostHeader step, + add extra examples

### DIFF
--- a/content/tutorials/iis.md
+++ b/content/tutorials/iis.md
@@ -102,7 +102,7 @@ Configured address to serve Grafana: http://yourdomain.com/existingsubpath/grafa
 
 {{< figure src="/static/img/docs/tutorials/IIS_url_rewrite.png"  max-width="800px" >}}
 
-6. If your version of Grafana is greater than 8.3.5 you will also need to configure the reverse proxy to preserve host headers
+6. If your version of Grafana is greater than 8.3.5, you also need to configure the reverse proxy to preserve host headers.
   - This can be achived by configuring the IIS config file by running this in a cmd prompt
   `%windir%\system32\inetsrv\appcmd.exe set config -section:system.webServer/proxy -preserveHostHeader:true /commit:apphost`
   - More information here https://github.com/grafana/grafana/issues/45261

--- a/content/tutorials/iis.md
+++ b/content/tutorials/iis.md
@@ -12,42 +12,66 @@ aliases: ["/docs/grafana/latest/tutorials/iis/"]
 
 # Use IIS with URL Rewrite as a Reverse Proxy
 
-If you want Grafana to be a subpath or subfolder under a website in IIS then the URL Rewrite module for ISS can be used to support this.
+If you want Grafana to be a subpath/subfolder under a website in IIS then the Application Request Routing (ARR) and URL Rewrite modules for ISS can be used to support this.
 
 Example:
 
-- Parent site: http://localhost:8080
+- Parent site: http://yourdomain.com:8080
 - Grafana: http://localhost:3000
 
-Grafana as a subpath: http://localhost:8080/grafana
+Grafana as a subpath: http://yourdomain.com:8080/grafana
+
+Other Examples:
+- The parent site could also look like http://localhost:8080 if the application was only served on the local server.
+- If your domain is served using https on port 443, and thus the port is not normally entered in the address of your site, then the need to specify a port for the parent site in the configuration steps below can be eliminated.
+ 
 
 ## Setup
 
-If you have not already done it, then a requirement is to install URL Rewrite module for IIS.
+If you have not already done it, install the URL Rewrite module for IIS.
 
-Download and install the URL Rewrite module for IIS: https://www.iis.net/downloads/microsoft/url-rewrite
+ - Download and install the URL Rewrite module for IIS: https://www.iis.net/downloads/microsoft/url-rewrite
 
 You will also need the Application Request Routing (ARR) module for IIS for proxy forwarding
 
-Download and install ARR module for IIS: https://www.iis.net/downloads/microsoft/application-request-routing
+ - Download and install ARR module for IIS: https://www.iis.net/downloads/microsoft/application-request-routing
 
 ## Grafana Config
 
-The Grafana config can be set by creating a file named `custom.ini` in the `conf` subdirectory of your Grafana installation. See the [installation instructions](http://docs.grafana.org/installation/windows/#configure) for more details.
+The Grafana config can be set by creating a file named/editing the existing file named `custom.ini` in the `conf` subdirectory of your Grafana installation. See the [installation instructions](http://docs.grafana.org/installation/windows/#configure) for more details.
 
-Given that the subpath should be `grafana` and the parent site is `localhost:8080` then add this to the `custom.ini` config file:
+Using the example from above, if the subpath is `grafana` (you can set this to whatever is required) and the parent site is `yourdomain.com:8080`, then you would add this to the `custom.ini` config file:
 
  ```bash
 [server]
-domain = localhost:8080
+domain = yourdomain.com:8080
 root_url = %(protocol)s://%(domain)s/grafana/
 ```
 
 Restart the Grafana server after changing the config file.
 
+Configured address to serve Grafana: http://yourdomain.com:8080/grafana
+
+------
+
+
+If you already had a subpath on your domain you would configure it like this
+- Your Parent Site Address: http://yourdomain.com/existingsubpath
+
+ ```bash
+[server]
+domain = yourdomain.com/existingsubpath
+root_url = %(protocol)s://%(domain)s/grafana/
+```
+
+Restart the Grafana server after changing the config file.
+
+Configured address to serve Grafana: http://yourdomain.com/existingsubpath/grafana
+
+
 ## IIS Config
 
-### Forward Proxy
+### Step 1: Forward Proxy
 
 1. Open the IIS Manager and click on the server
 2. In the admin console for the server, double click on the Application Request Routing option:
@@ -57,9 +81,9 @@ Restart the Grafana server after changing the config file.
 
 **Note:** If you don't enable the Forward Proxy, you will most likely get 404 Not Found if you only apply the URL Rewrite rule
 
-### URL Rewriting
+### Step 2: URL Rewriting
 
-1. Open the IIS Manager and click on the parent website
+1. In the IIS Manager click on the website that grafana will run under, ie. select the website that is bound to the http://yourdomain.com domain
 2. In the admin console for this website, double click on the URL Rewrite option:
 
 {{< figure src="/static/img/docs/tutorials/IIS_admin_console.png"  max-width="800px" >}}
@@ -69,8 +93,8 @@ Restart the Grafana server after changing the config file.
 
 {{< figure src="/static/img/docs/tutorials/IIS_add_inbound_rule.png"  max-width="800px" >}}
 
-5. Create an Inbound Rule for the parent website (localhost:8080 in this example) with the following settings:
-  - pattern: `grafana(/)?(.*)`
+5. Create an Inbound Rule for the website with the following settings:
+  - pattern: `grafana(/)?(.*)`  (if you have customised the subpath that will be used, use that instead of `grafana`)
   - check the `Ignore case` checkbox
   - rewrite URL set to `http://localhost:3000/{R:2}`
   - check the `Append query string` checkbox
@@ -78,15 +102,22 @@ Restart the Grafana server after changing the config file.
 
 {{< figure src="/static/img/docs/tutorials/IIS_url_rewrite.png"  max-width="800px" >}}
 
-Finally, navigate to `http://localhost:8080/grafana` (replace `http://localhost:8080` with your parent domain) and you should come to the Grafana login page.
+6. If your version of Grafana is greater than 8.3.5 you will also need to configure the reverse proxy to preserve host headers
+  - This can be achived by configuring the IIS config file by running this in a cmd prompt
+  `%windir%\system32\inetsrv\appcmd.exe set config -section:system.webServer/proxy -preserveHostHeader:true /commit:apphost`
+  - More information here https://github.com/grafana/grafana/issues/45261
+
+
+
+Finally, navigate to `http://yourdomain.com:8080/grafana` and you should come to the Grafana login page.
 
 ## Troubleshooting
 
 ### 404 error
 
-When navigating to the Grafana URL (`http://localhost:8080/grafana` in the example above) and a `HTTP Error 404.0 - Not Found` error is returned then either:
+When navigating to the Grafana URL (`http://yourdomain.com:8080/grafana`) and a `HTTP Error 404.0 - Not Found` error is returned, then either:
 
-- the pattern for the Inbound Rule is incorrect. Edit the rule, click on the `Test pattern...` button, test the part of the URL after `http://localhost:8080/` and make sure it matches. For `grafana/login` the test should return 3 capture groups: {R:0}: `grafana` {R:1}: `/` and {R:2}: `login`.
+- The pattern for the Inbound Rule is incorrect. Edit the rule, click on the `Test pattern...` button, test the part of the URL after `http://yourdomain.com:8080/` and make sure it matches. For `grafana/login` the test should return 3 capture groups: {R:0}: `grafana` {R:1}: `/` and {R:2}: `login`.
 - The `root_url` setting in the Grafana config file does not match the parent URL with subpath.
 
 ### Grafana Website only shows text with no images or css
@@ -107,4 +138,8 @@ When navigating to the Grafana URL (`http://localhost:8080/grafana` in the examp
 
     The Rewrite URL should not include the subpath.
 
-    The Rewrite URL should contain the capture group from the pattern matching that returns the part of the URL after the subpath. The pattern used above returns 3 capture groups and the third one {R:2} returns the part of the URL after `http://localhost:8080/grafana/`.
+    The Rewrite URL should contain the capture group from the pattern matching that returns the part of the URL after the subpath. The pattern used above returns 3 capture groups and the third one {R:2} returns the part of the URL after `http://yourdomain.com:8080/grafana/`.
+    
+### You see an 'Error updating options: origin not allowed' error
+- Ensure you have undertaken step 6 above, to configure IIS to preserve host headers by edit IIS config by running this in cmd prompt:
+ `%windir%\system32\inetsrv\appcmd.exe set config -section:system.webServer/proxy -preserveHostHeader:true /commit:apphost`

--- a/content/tutorials/iis.md
+++ b/content/tutorials/iis.md
@@ -28,7 +28,7 @@ Other Examples:
 
 ## Setup
 
-If you have not already done it, install the URL Rewrite module for IIS.
+Install the URL Rewrite module for IIS.
 
  - Download and install the URL Rewrite module for IIS: https://www.iis.net/downloads/microsoft/url-rewrite
 

--- a/content/tutorials/iis.md
+++ b/content/tutorials/iis.md
@@ -55,7 +55,7 @@ Configured address to serve Grafana: http://yourdomain.com:8080/grafana
 ------
 
 
-If you already had a subpath on your domain you would configure it like this
+If you already have a subpath on your domain, configure it as follows:
 - Your Parent Site Address: http://yourdomain.com/existingsubpath
 
  ```bash

--- a/content/tutorials/iis.md
+++ b/content/tutorials/iis.md
@@ -138,7 +138,7 @@ When navigating to the Grafana URL (`http://yourdomain.com:8080/grafana`) and a 
 
     The Rewrite URL should not include the subpath.
 
-    The Rewrite URL should contain the capture group from the pattern matching that returns the part of the URL after the subpath. The pattern used above returns 3 capture groups and the third one {R:2} returns the part of the URL after `http://yourdomain.com:8080/grafana/`.
+    The Rewrite URL should contain the capture group from the pattern matching that returns the part of the URL after the subpath. The pattern used above returns three capture groups and the third one {R:2} returns the part of the URL after `http://yourdomain.com:8080/grafana/`.
     
 ### You see an 'Error updating options: origin not allowed' error
 - Ensure you have undertaken step 6 above, to configure IIS to preserve host headers by edit IIS config by running this in cmd prompt:

--- a/content/tutorials/iis.md
+++ b/content/tutorials/iis.md
@@ -22,7 +22,7 @@ Example:
 Grafana as a subpath: http://yourdomain.com:8080/grafana
 
 Other Examples:
-- The parent site could also look like http://localhost:8080 if the application was only served on the local server.
+- If the application is only served on the local server, the parent site can also look like http://localhost:8080. 
 - If your domain is served using https on port 443, and thus the port is not normally entered in the address of your site, then the need to specify a port for the parent site in the configuration steps below can be eliminated.
  
 

--- a/content/tutorials/iis.md
+++ b/content/tutorials/iis.md
@@ -83,7 +83,7 @@ Configured address to serve Grafana: http://yourdomain.com/existingsubpath/grafa
 
 ### Step 2: URL Rewriting
 
-1. In the IIS Manager click on the website that grafana will run under, ie. select the website that is bound to the http://yourdomain.com domain
+1. In the IIS Manager, click on the website that grafana will run under. For example, select the website that is bound to the http://yourdomain.com domain.
 2. In the admin console for this website, double click on the URL Rewrite option:
 
 {{< figure src="/static/img/docs/tutorials/IIS_admin_console.png"  max-width="800px" >}}


### PR DESCRIPTION
- Added preserveHostHeader step to remove origin errors 

- The primary example of `localhost:8080` has been changed to `yourdomain.com:8080` to both provide an example for an external domain, but also to reduce opportunity for readers to get confused about how the reverse proxy works, so they can see it can be used for both internal and external websites

- Added extra emphasis to `IIS Config` steps by labelling them Step 1 and Step 2, because somehow we managed to miss step 1 when configuring our site.